### PR TITLE
FIX: cpac_templates.tar.gz unpacking incorrect directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,9 +177,9 @@ RUN cd /tmp && \
 
 # install cpac templates
 COPY cpac_templates.tar.gz /cpac_resources/cpac_templates.tar.gz
-RUN tar xzvf /cpac_resources/cpac_templates.tar.gz && \
+RUN tar xzvf /cpac_resources/cpac_templates.tar.gz -C /cpac_resources && \
     rm -f /cpac_resources/cpac_templates.tar.gz
-    
+
 # install cpac
 RUN pip install git+https://github.com/jdkent/C-PAC.git@fix_pylock
 


### PR DESCRIPTION
Fixes #28 
Introduced this bug in my last commit, cpac_templates.tar.gz was unpacking in the root directory, should unpack within /cpac_resources to match with [default_pipeline.yaml](https://github.com/BIDS-Apps/CPAC/blob/master/default_pipeline.yaml#L333)

2 steps forward, one step back... but this fixes it.